### PR TITLE
Add flask cors to management api

### DIFF
--- a/src/api/app.py
+++ b/src/api/app.py
@@ -1,4 +1,6 @@
 from flask import Flask
+from flask_cors import CORS
 
 # app initialization
 app = Flask(__name__)
+CORS(app)

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,6 +1,7 @@
 aniso8601==3.0.2
 Click==7.0
 Flask==1.0.2
+Flask-Cors==3.0.6
 Flask-GraphQL==2.0.0
 Flask-SQLAlchemy==2.3.2
 graphene==2.1.3


### PR DESCRIPTION
The management api wasn’t allowed to accept requests from other origins. Added flask cors fixes this.