### PR TITLE
Variable port number for the API

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ If GOB-Workflow project has already been initialised then execute:
     docker-compose up management_database &
 ```
 
+Default, the API is exposed at port 5001.
+ 
 Start the API
 
 ```
@@ -100,7 +102,9 @@ Start the API
     python -m api
 ```
 
-The API is exposed at http://127.0.0.1:5000/ when running locally.
+The API is exposed at http://127.0.0.1:5001/ when running locally.
+
+The port can be changed by setting the GOB_MANAGEMENT_PORT variable.
 
 ### Tests
 

--- a/src/api/__main__.py
+++ b/src/api/__main__.py
@@ -5,6 +5,8 @@ This module is the main module for the API server.
 On startup the api is instantiated.
 
 """
+import os
+
 from api.api import app
 
-app.run()
+app.run(port=os.getenv("GOB_MANAGEMENT_PORT", 5001))


### PR DESCRIPTION
The API is exposed at port 5001 (default value)
or the value from the environment variable GOB_MANAGEMENT_PORT