### PR TITLE
Security fix

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -21,7 +21,7 @@ graphql-relay==0.4.5
 graphql-server-core==1.1.1
 greenlet==0.4.15
 itsdangerous==0.24
-Jinja2==2.10
+Jinja2==2.10.1
 MarkupSafe==1.0
 mccabe==0.6.1
 monotonic==1.5


### PR DESCRIPTION
Known high severity security vulnerability detected in Jinja2 < 2.10.1
defined in requirements.txt.
requirements.txt update suggested: Jinja2 ~> 2.10.1.