### PR TITLE
53 fix log notification 2

### DIFF
--- a/src/Dockerfile.test
+++ b/src/Dockerfile.test
@@ -8,11 +8,13 @@ WORKDIR /app
 COPY requirements.txt /app/
 RUN pip3 install --no-cache-dir -r requirements.txt
 RUN rm requirements.txt
+RUN rm -rf /app/src/gobcore/tests
 
 # Copy gobmanagement module
 COPY gobmanagement gobmanagement
 
 # Copy tests
+COPY tests tests
 COPY .flake8 .flake8
 COPY test.sh test.sh
 

--- a/src/gobmanagement/api.py
+++ b/src/gobmanagement/api.py
@@ -21,12 +21,14 @@ def _secure():
     return 'Secure access OK'
 
 
-def session_middleware(next, root, info, **args):
-    with session_scope() as session:
-        info.context = dict(
-            session = session
-        )
+def create_session_middleware(session_backend=session_scope):
+    def session_middleware(next, root, info, **args):
+        with session_backend() as session:
+            info.context = dict(
+                session=session
+            )
         return next(root, info, **args)
+    return session_middleware
 
 
 CORS(app, origins=ALLOWED_ORIGINS)
@@ -34,7 +36,7 @@ CORS(app, origins=ALLOWED_ORIGINS)
 _graphql = GraphQLView.as_view(
                 'graphql',
                 schema=schema,
-                middleware=[session_middleware],
+                middleware=[create_session_middleware()],
                 graphiql=True  # for having the GraphiQL interface
             )
 

--- a/src/gobmanagement/api.py
+++ b/src/gobmanagement/api.py
@@ -4,7 +4,7 @@ from flask_socketio import SocketIO
 
 from gobmanagement.config import ALLOWED_ORIGINS, API_BASE_PATH
 from gobmanagement.app import app
-from gobmanagement.database.base import db_session
+from gobmanagement.database.base import db_session, session_scope
 from gobmanagement.schemas import schema
 from gobmanagement.socket import LogBroadcaster
 
@@ -21,11 +21,18 @@ def _secure():
     return 'Secure access OK'
 
 
+def session_middleware(next, root, info, **args):
+    with session_scope() as session:
+        info.session = session
+        return next(root, info, **args)
+
+
 CORS(app, origins=ALLOWED_ORIGINS)
 
 _graphql = GraphQLView.as_view(
                 'graphql',
                 schema=schema,
+                middleware=[session_middleware],
                 graphiql=True  # for having the GraphiQL interface
             )
 

--- a/src/gobmanagement/api.py
+++ b/src/gobmanagement/api.py
@@ -23,7 +23,9 @@ def _secure():
 
 def session_middleware(next, root, info, **args):
     with session_scope() as session:
-        info.session = session
+        info.context = dict(
+            session = session
+        )
         return next(root, info, **args)
 
 

--- a/src/gobmanagement/api.py
+++ b/src/gobmanagement/api.py
@@ -40,6 +40,7 @@ _graphql = GraphQLView.as_view(
                 graphiql=True  # for having the GraphiQL interface
             )
 
+
 # Routes
 ROUTES = [
     # Health check URL

--- a/src/gobmanagement/database/__init__.py
+++ b/src/gobmanagement/database/__init__.py
@@ -2,20 +2,18 @@ from sqlalchemy import func
 
 from gobcore.model.sa.management import Log, Service
 
-from gobmanagement.database.base import db_session
 
-
-def get_last_logid():
+def get_last_logid(session):
     """Get logid of last Log message
 
     :return: value of last logid or None
     """
-    return db_session.query(func.max(Log.logid)).scalar()
+    return session.query(func.max(Log.logid)).scalar()
 
 
-def get_last_service_timestamp():
+def get_last_service_timestamp(session):
     """Get timestamp of most recent service
 
     :return: value of most recent timestamp or None
     """
-    return db_session.query(func.max(Service.timestamp)).scalar()
+    return session.query(func.max(Service.timestamp)).scalar()

--- a/src/gobmanagement/database/base.py
+++ b/src/gobmanagement/database/base.py
@@ -24,8 +24,8 @@ Base.query = db_session.query_property()  # Used by graphql to execute queries
 
 @contextmanager
 def session_scope(readonly=False, backend=Session):
-    session = Session()
-    if not readonly:
+    session = backend()
+    if readonly:
         session.flush = lambda: None
     try:
         yield session
@@ -34,5 +34,4 @@ def session_scope(readonly=False, backend=Session):
     except Exception:
         session.rollback()
         raise
-    finally:
-        session.close()
+    session.close()

--- a/src/gobmanagement/database/base.py
+++ b/src/gobmanagement/database/base.py
@@ -18,7 +18,7 @@ Base.metadata.bind = engine  # Bind engine to metadata of the base class
 # Create database session object
 maker = sessionmaker(bind=engine, expire_on_commit=False)
 Session = scoped_session(maker)
-db_session = Session()  # should not be used
+db_session = Session  # should not be used
 Base.query = db_session.query_property()  # Used by graphql to execute queries
 
 

--- a/src/setup.py
+++ b/src/setup.py
@@ -1,0 +1,26 @@
+from setuptools import setup, find_packages
+
+setup(
+    name='gobmanagement',
+    version='0.1',
+    description='GOB Management Components',
+    url='https://github.com/Amsterdam/GOB-Management',
+    author='Datapunt',
+    author_email='',
+    license='MPL-2.0',
+    install_requires=[
+        "flask",
+        "flask_cors",
+        "flask_graphql",
+        "flask_socketio",
+        "flask_sqlalchemy",
+        "gobcore",
+        "graphene",
+        "graphene_sqlalchemy",
+        "sqlalchemy"
+    ],
+    packages=find_packages(exclude=['tests*']),
+    dependency_links=[
+        'git+https://github.com/Amsterdam/objectstore.git@v1.0#egg=datapunt-objectstore',
+    ],
+)

--- a/src/test.sh
+++ b/src/test.sh
@@ -7,7 +7,7 @@ echo "Running style checks"
 flake8
 
 echo "Running unit tests"
-#pytest
+pytest
 
 echo "Running coverage tests"
 #export COVERAGE_FILE=/tmp/.coverage

--- a/src/tests/test_api.py
+++ b/src/tests/test_api.py
@@ -1,0 +1,20 @@
+import collections
+import contextlib
+
+from gobmanagement import api
+
+
+@contextlib.contextmanager
+def mock_session(*args, **kwargs):
+    yield 10
+
+
+def test_session_middleware():
+    middleware = api.create_session_middleware(
+        mock_session
+    )
+    result = middleware(
+        lambda r, i: i.context['session'],
+        {}, collections.namedtuple("info", ["context"])
+    )
+    assert result == 10

--- a/src/tests/test_database_base.py
+++ b/src/tests/test_database_base.py
@@ -6,7 +6,6 @@ import pytest
 from gobmanagement.database import base
 
 
-
 def test_session_scope_rw():
     session_mock = MagicMock()
     with base.session_scope(backend=lambda: session_mock) as session:

--- a/src/tests/test_database_base.py
+++ b/src/tests/test_database_base.py
@@ -1,0 +1,30 @@
+from unittest.mock import MagicMock
+import types
+
+import pytest
+
+from gobmanagement.database import base
+
+
+
+def test_session_scope_rw():
+    session_mock = MagicMock()
+    with base.session_scope(backend=lambda: session_mock) as session:
+        assert not isinstance(session_mock.flush, types.LambdaType)
+    session_mock.commit.assert_called()
+    session_mock.close.assert_called()
+
+def test_session_scope_ro():
+    session_mock = MagicMock()
+    with base.session_scope(True, backend=lambda: session_mock) as session:
+        assert isinstance(session.flush, types.LambdaType)
+    session_mock.commit.assert_not_called()
+    session_mock.close.assert_called()
+
+def test_session_scope_exc():
+    session_mock = MagicMock()
+    with pytest.raises(Exception):
+        with base.session_scope(backend=lambda: session_mock) as session:
+            raise RuntimeError
+    session_mock.commit.assert_not_called()
+    session_mock.rollback.assert_called()


### PR DESCRIPTION
Related issue: https://github.com/Amsterdam/GOB-Management/issues/49

*Problem*: Table `logs` is blocked by the `get_last_log_id` query from GOB-Management, transactions are not closed.

*Solution*: Close sessions after each `get_last_log_id` cycle

*Additionally*:
 * added tests  (enabled pytest as well in ./test.sh)
 * added setup.py (so we can actually run pytest)
 * added scoped_session to graphql's ResolveInfo.context so we use that session in queries (not implemented in actual `_resolve` functions yet)


**Note**: the dependencies for `setup.py` are extracted via `pydeps --external`. Output:

```
[
    "flask",
    "flask_cors",
    "flask_graphql",
    "flask_socketio",
    "flask_sqlalchemy",
    "gobcore",
    "graphene",
    "graphene_sqlalchemy",
    "sqlalchemy"
]
```