### PR TITLE
Provide for job create API endpoint

### DIFF
--- a/src/test.sh
+++ b/src/test.sh
@@ -10,4 +10,4 @@ echo "Running unit tests"
 pytest
 
 echo "Running coverage tests"
-pytest --cov=gobmanagement --cov-report html --cov-fail-under=80
+pytest --cov=gobmanagement --cov-report html --cov-fail-under=81

--- a/src/tests/grpc/services/test_jobs.py
+++ b/src/tests/grpc/services/test_jobs.py
@@ -91,3 +91,11 @@ class TestJobsServicer(TestCase):
             'arg2': 'someval2',
             # arg3 is ignored, not set in request
         })
+
+        result = jobs_servicer._extract_args(start_command, {'arg1': 'someval1', 'arg2': 'someval2', 'arg3': None})
+
+        self.assertEqual(result, {
+            'arg1': 'someval1',
+            'arg2': 'someval2',
+            # arg3 is ignored, not set in request
+        })

--- a/src/tests/test_api.py
+++ b/src/tests/test_api.py
@@ -1,8 +1,9 @@
+from unittest import TestCase, mock
+
 import collections
 import contextlib
 
 from gobmanagement import api
-
 
 @contextlib.contextmanager
 def mock_session(*args, **kwargs):
@@ -18,3 +19,34 @@ def test_session_middleware():
         {}, collections.namedtuple("info", ["context"])
     )
     assert result == 10
+
+class MockedRequest:
+
+    def __init__(self):
+        self.host = "any host"
+        self.headers = {}
+
+mock_request = MockedRequest()
+
+class TestJob(TestCase):
+
+    def setUp(self) -> None:
+        mock_request = MockedRequest()
+
+    @mock.patch('gobmanagement.api.request', mock_request)
+    def test_job_errors(self):
+        msg, status = api._job()
+        assert status == 401
+
+        mock_request.headers['X-Auth-Userid'] = "any userid"
+        msg, status = api._job()
+        assert status == 403
+
+        mock_request.headers['X-Auth-Roles'] = "any role"
+        msg, status = api._job()
+        assert status == 403
+
+        mock_request.headers['X-Auth-Roles'] = "any role gob_adm"
+        mock_request.get_json = lambda silent: {}
+        msg, status = api._job()
+        assert status == 400


### PR DESCRIPTION
The endpoint is only available for authenticated and authorized users.

Authentication is controlled by gatekeeper.
Authorization is checked in the method.

The gRPC JobServicer is used to check the job parameters and start the job.