### PR TITLE
Update GOB-Core

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -13,7 +13,7 @@ Flask-SQLAlchemy==2.3.2
 GeoAlchemy2==0.5.0
 geomet==0.2.0.post2
 gevent==1.3.7
--e git+https://github.com/Amsterdam/GOB-Core.git@v0.15.8#egg=gobcore
+-e git+https://github.com/Amsterdam/GOB-Core.git@v0.16.0#egg=gobcore
 grpcio-tools==1.21.1
 graphene==2.1.3
 graphene-sqlalchemy==2.1.0


### PR DESCRIPTION
De update is nodig om de import van BAG onderzoeken te kunnen starten vanuit Iris