### PR TITLE
Remove session_middleware on GraphQL endpoint.

### DIFF
--- a/src/gobmanagement/api.py
+++ b/src/gobmanagement/api.py
@@ -7,7 +7,7 @@ from gobcore.model import GOBModel
 
 from gobmanagement.config import ALLOWED_ORIGINS, API_BASE_PATH
 from gobmanagement.app import app
-from gobmanagement.database.base import db_session, session_scope
+from gobmanagement.database.base import db_session
 from gobmanagement.schemas import schema
 from gobmanagement.socket import LogBroadcaster
 from gobmanagement.auth import RequestUser
@@ -96,22 +96,11 @@ def _catalogs():
     return jsonify(result), 200, {'Content-Type': 'application/json'}
 
 
-def create_session_middleware(session_backend=session_scope):
-    def session_middleware(next, root, info, **args):
-        with session_backend() as session:
-            info.context = dict(
-                session=session
-            )
-        return next(root, info, **args)
-    return session_middleware
-
-
 CORS(app, origins=ALLOWED_ORIGINS)
 
 _graphql = GraphQLView.as_view(
                 'graphql',
                 schema=schema,
-                middleware=[create_session_middleware()],
                 graphiql=True  # for having the GraphiQL interface
             )
 

--- a/src/tests/test_api.py
+++ b/src/tests/test_api.py
@@ -1,24 +1,6 @@
 from unittest import TestCase, mock
 
-import collections
-import contextlib
-
 from gobmanagement import api
-
-@contextlib.contextmanager
-def mock_session(*args, **kwargs):
-    yield 10
-
-
-def test_session_middleware():
-    middleware = api.create_session_middleware(
-        mock_session
-    )
-    result = middleware(
-        lambda r, i: i.context['session'],
-        {}, collections.namedtuple("info", ["context"])
-    )
-    assert result == 10
 
 class MockedRequest:
 


### PR DESCRIPTION
It is not clear what this middleware does, and there are no (obvious) references to the added field in the code.
At first sight nothing breaks without the session_middleware.
The session_middleware had a serious impact on the GraphQL endpoint performance.
Removing the middleware for now. If something does break we'll have to find another way (without middleware) to fix this.