### PR TITLE
Provide for public workflow state endpoints

### DIFF
--- a/src/gatekeeper.conf
+++ b/src/gatekeeper.conf
@@ -38,6 +38,9 @@ resources:
 # Websockets are used to signal updates
 - uri: /gob_management/socket.io/*
   white-listed: true
+# Basic state endpoints are public
+- uri: /gob_management/state/*
+  white-listed: true
 # /status endpoints are for internal use only, no authorization required
 - uri: /status/*
   white-listed: true

--- a/src/gobmanagement/database/__init__.py
+++ b/src/gobmanagement/database/__init__.py
@@ -1,4 +1,4 @@
-from sqlalchemy import func
+from sqlalchemy import func, text
 
 from gobmanagement.database.base import session_scope
 
@@ -54,3 +54,20 @@ COMMIT;
         result = session.execute(stmt)
     result.close()
     return unfinished_jobs()
+
+
+def get_process_state(process_id):
+    """
+    Returns the state of a process as a list of jobs {id, status}
+
+    :param process_id:
+    :return:
+    """
+
+    # Use query parameters to protect the query against SQL injection
+    stmt = text("SELECT id, status FROM jobs WHERE process_id =:process_id").bindparams(process_id=process_id)
+    with session_scope(True) as session:
+        result = session.execute(stmt)
+    process_state = [dict(row) for row in result.fetchall()]
+    result.close()
+    return process_state

--- a/src/test.sh
+++ b/src/test.sh
@@ -13,4 +13,4 @@ echo "Running unit tests"
 pytest
 
 echo "Running coverage tests"
-pytest --cov=gobmanagement --cov-report html --cov-fail-under=82
+pytest --cov=gobmanagement --cov-report html --cov-fail-under=83

--- a/src/tests/test_database.py
+++ b/src/tests/test_database.py
@@ -1,7 +1,9 @@
+from sqlalchemy.sql.elements import TextClause
+
 from unittest import TestCase, mock
 from unittest.mock import MagicMock
 
-from gobmanagement.database import remove_job, unfinished_jobs
+from gobmanagement.database import remove_job, unfinished_jobs, get_process_state
 
 class TestDatabase(TestCase):
 
@@ -27,3 +29,15 @@ class TestDatabase(TestCase):
         mock_scope.return_value.__enter__.return_value = mock_session
         remove_job('any id')
         mock_session.execute.assert_called_once()
+
+    @mock.patch('gobmanagement.database.session_scope')
+    def test_process_state(self, mock_scope):
+        mock_session = MagicMock()
+        mock_scope.return_value.__enter__.return_value = mock_session
+
+        result = get_process_state("any process id")
+        self.assertEqual(result, [])
+        mock_session.execute.assert_called_once()
+        args, _ = mock_session.execute.call_args_list[0]
+        self.assertEqual(len(args), 1)
+        self.assertTrue(isinstance(args[0], TextClause))


### PR DESCRIPTION
To allow third party applications to read the workflow state
Example: gob-test that needs to know if a process has finished before starting a next one